### PR TITLE
Simplify view builds with shared root Vite configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,3 +237,14 @@ export default {
   plugins: [tailwindcss(), autoprefixer()],
 }
 ```
+
+## Views Vite Configuration
+
+OpenCore treats Vite as the primary frontend build system for views:
+
+- The recommended setup is a shared `vite.config.ts` in the same root where `opencore.config.ts` exists.
+- View folders (for example `resources/chat/view`) do not need a local `vite.config.ts` by default.
+- During build, OpenCore first checks for a local `vite.config.*` in the view directory.
+- If local config is missing, OpenCore falls back to the root `vite.config.*` and builds the target view with that shared config.
+
+For advanced cases, keep local config files as override layers that extend shared root defaults with `mergeConfig`.

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -394,6 +394,19 @@ func detectViewFramework(viewPath string) string {
 }
 
 func hasViteConfig(viewPath string) bool {
+	if findViteConfigPath(viewPath) != "" {
+		return true
+	}
+
+	projectRoot := findProjectRootFromPath(viewPath)
+	if projectRoot != "" && findViteConfigPath(projectRoot) != "" {
+		return true
+	}
+
+	return false
+}
+
+func findViteConfigPath(dir string) string {
 	configFiles := []string{
 		"vite.config.js",
 		"vite.config.ts",
@@ -402,12 +415,38 @@ func hasViteConfig(viewPath string) bool {
 	}
 
 	for _, fileName := range configFiles {
-		if _, err := os.Stat(filepath.Join(viewPath, fileName)); err == nil {
-			return true
+		candidate := filepath.Join(dir, fileName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
 		}
 	}
 
-	return false
+	return ""
+}
+
+func findProjectRootFromPath(startPath string) string {
+	currentPath, err := filepath.Abs(startPath)
+	if err != nil {
+		return ""
+	}
+
+	info, err := os.Stat(currentPath)
+	if err == nil && !info.IsDir() {
+		currentPath = filepath.Dir(currentPath)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(currentPath, "opencore.config.ts")); err == nil {
+			return currentPath
+		}
+
+		parent := filepath.Dir(currentPath)
+		if parent == currentPath {
+			return ""
+		}
+
+		currentPath = parent
+	}
 }
 
 func resolveViewsConfig(resourcePath string, explicit *config.ViewsConfig) *config.ViewsConfig {

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -414,6 +414,28 @@ func TestDetectViewFramework_PrefersViteConfig(t *testing.T) {
 	}
 }
 
+func TestDetectViewFramework_UsesProjectRootViteConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	viewDir := filepath.Join(tmpDir, "resources", "chat", "view")
+	if err := os.MkdirAll(filepath.Join(viewDir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "opencore.config.ts"), []byte("export default {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "vite.config.ts"), []byte("export default {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(viewDir, "src", "main.ts"), []byte("export {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	framework := detectViewFramework(viewDir)
+	if framework != "vite" {
+		t.Fatalf("Expected framework 'vite', got '%s'", framework)
+	}
+}
+
 func TestCollectAllTasks_ViewsFrameworkWithoutPathUsesAutodiscovery(t *testing.T) {
 	tmpDir := t.TempDir()
 	resourceDir := filepath.Join(tmpDir, "resources", "auth")

--- a/internal/builder/embedded/views.js
+++ b/internal/builder/embedded/views.js
@@ -326,15 +326,20 @@ async function buildViteViews(viewPath, outDir, options = {}) {
     const projectRoot = findProjectRoot(viewPath)
     const rootViteConfig = projectRoot ? findViteConfigPath(projectRoot) : null
 
-    let commandParts = [`${baseCommand} --outDir "${absOutDir}"`]
+    let commandParts = [baseCommand]
     let runCwd = viewPath
+    const spawnEnv = { ...process.env }
 
     if (localViteConfig) {
+        commandParts.push(`--outDir "${absOutDir}"`)
         commandParts.push(`--config "${localViteConfig.replace(/\\/g, '/')}"`)
     } else if (rootViteConfig) {
         commandParts.push(`--config "${rootViteConfig.replace(/\\/g, '/')}"`)
-        commandParts.push(`--root "${path.resolve(viewPath).replace(/\\/g, '/')}"`)
+        spawnEnv.OPENCORE_VIEW_ROOT = path.resolve(viewPath)
+        spawnEnv.OPENCORE_VIEW_OUTDIR = absOutDir
         runCwd = projectRoot
+    } else {
+        commandParts.push(`--outDir "${absOutDir}"`)
     }
 
     const buildCommand = commandParts.join(' ')
@@ -344,7 +349,7 @@ async function buildViteViews(viewPath, outDir, options = {}) {
     const spawn = require('child_process').spawn
 
     await new Promise((resolve, reject) => {
-        const proc = spawn(buildCommand, { cwd: runCwd, stdio: 'inherit', shell: true })
+        const proc = spawn(buildCommand, { cwd: runCwd, stdio: 'inherit', shell: true, env: spawnEnv })
         proc.on('close', code => {
             if (code === 0) {
                 resolve()

--- a/internal/builder/embedded/views.js
+++ b/internal/builder/embedded/views.js
@@ -269,6 +269,19 @@ async function loadProjectPostcssPlugins(viewPath, options = {}) {
 }
 
 function detectViteFramework(viewPath) {
+    if (findViteConfigPath(viewPath)) {
+        return true
+    }
+
+    const projectRoot = findProjectRoot(viewPath)
+    if (projectRoot && findViteConfigPath(projectRoot)) {
+        return true
+    }
+
+    return false
+}
+
+function findViteConfigPath(dirPath) {
     const configFiles = [
         'vite.config.js',
         'vite.config.ts',
@@ -277,12 +290,13 @@ function detectViteFramework(viewPath) {
     ]
 
     for (const fileName of configFiles) {
-        if (fs.existsSync(path.join(viewPath, fileName))) {
-            return true
+        const candidate = path.join(dirPath, fileName)
+        if (fs.existsSync(candidate)) {
+            return candidate
         }
     }
 
-    return false
+    return null
 }
 
 async function buildViteViews(viewPath, outDir, options = {}) {
@@ -308,14 +322,29 @@ async function buildViteViews(viewPath, outDir, options = {}) {
 
     const absOutDir = path.resolve(outDir).replace(/\\/g, '/')
     const baseCommand = options.buildCommand || execCmd(options, 'vite', ['build'])
-    const buildCommand = `${baseCommand} --outDir "${absOutDir}"`
+    const localViteConfig = findViteConfigPath(viewPath)
+    const projectRoot = findProjectRoot(viewPath)
+    const rootViteConfig = projectRoot ? findViteConfigPath(projectRoot) : null
+
+    let commandParts = [`${baseCommand} --outDir "${absOutDir}"`]
+    let runCwd = viewPath
+
+    if (localViteConfig) {
+        commandParts.push(`--config "${localViteConfig.replace(/\\/g, '/')}"`)
+    } else if (rootViteConfig) {
+        commandParts.push(`--config "${rootViteConfig.replace(/\\/g, '/')}"`)
+        commandParts.push(`--root "${path.resolve(viewPath).replace(/\\/g, '/')}"`)
+        runCwd = projectRoot
+    }
+
+    const buildCommand = commandParts.join(' ')
 
     console.log(`[views] Vite detected, running: ${buildCommand}`)
 
     const spawn = require('child_process').spawn
 
     await new Promise((resolve, reject) => {
-        const proc = spawn(buildCommand, { cwd: viewPath, stdio: 'inherit', shell: true })
+        const proc = spawn(buildCommand, { cwd: runCwd, stdio: 'inherit', shell: true })
         proc.on('close', code => {
             if (code === 0) {
                 resolve()

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -205,6 +205,8 @@ func GenerateStarterProject(targetPath, projectName string, installIdentity bool
 		"package.json":        filepath.Join(targetPath, "package.json"),
 		"opencore.config.ts":  filepath.Join(targetPath, "opencore.config.ts"),
 		"pnpm-workspace.yaml": filepath.Join(targetPath, "pnpm-workspace.yaml"),
+		"vite.config.ts":      filepath.Join(targetPath, "vite.config.ts"),
+		"postcss.config.mjs":  filepath.Join(targetPath, "postcss.config.mjs"),
 		"core/package.json":   filepath.Join(targetPath, "core", "package.json"),
 		"tsconfig.json":       filepath.Join(targetPath, "tsconfig.json"),
 		".gitignore":          filepath.Join(targetPath, ".gitignore"),

--- a/internal/templates/embed_test.go
+++ b/internal/templates/embed_test.go
@@ -50,6 +50,12 @@ func TestGenerateStarterProjectWithFiveMAdapter(t *testing.T) {
 	if !strings.Contains(string(packageContent), "\"@open-core/fivem-adapter\": \"latest\"") {
 		t.Fatal("expected generated package.json to include @open-core/fivem-adapter")
 	}
+	if !strings.Contains(string(packageContent), "\"vite\": \"^7.1.0\"") {
+		t.Fatal("expected generated package.json to include vite")
+	}
+	if !strings.Contains(string(packageContent), "\"postcss\": \"^8.5.6\"") {
+		t.Fatal("expected generated package.json to include postcss")
+	}
 
 	if _, err := os.Stat(filepath.Join(targetPath, "core", "src", "features")); err != nil {
 		t.Fatalf("expected core/src/features directory: %v", err)
@@ -59,6 +65,12 @@ func TestGenerateStarterProjectWithFiveMAdapter(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(targetPath, "core", "src", "server", "main.ts")); !os.IsNotExist(err) {
 		t.Fatal("did not expect legacy server/main.ts in starter")
+	}
+	if _, err := os.Stat(filepath.Join(targetPath, "vite.config.ts")); err != nil {
+		t.Fatalf("expected root vite.config.ts: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetPath, "postcss.config.mjs")); err != nil {
+		t.Fatalf("expected root postcss.config.mjs: %v", err)
 	}
 }
 

--- a/internal/templates/starter-project/package.json
+++ b/internal/templates/starter-project/package.json
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "@open-core/cli": "latest",
+    "vite": "^7.1.0",
+    "postcss": "^8.5.6",
+    "autoprefixer": "^10.4.21",
     "typescript": "^5.3.3",
     "esbuild": "^0.27.4",
     "@swc/core": "^1.15.7",

--- a/internal/templates/starter-project/postcss.config.mjs
+++ b/internal/templates/starter-project/postcss.config.mjs
@@ -1,0 +1,5 @@
+import autoprefixer from 'autoprefixer'
+
+export default {
+  plugins: [autoprefixer()],
+}

--- a/internal/templates/starter-project/vite.config.ts
+++ b/internal/templates/starter-project/vite.config.ts
@@ -1,0 +1,39 @@
+import path from 'node:path'
+import { defineConfig, type UserConfig } from 'vite'
+
+export type OpenCoreViteConfigOptions = {
+  root: string
+  outDir?: string
+}
+
+export function createOpenCoreViteConfig(options: OpenCoreViteConfigOptions): UserConfig {
+  const root = path.resolve(options.root)
+
+  return defineConfig({
+    root,
+    resolve: {
+      alias: {
+        '@': path.join(root, 'src'),
+      },
+    },
+    css: {
+      devSourcemap: true,
+    },
+    build: {
+      outDir: options.outDir ?? path.join(root, 'dist'),
+      emptyOutDir: true,
+      sourcemap: false,
+      target: 'es2020',
+    },
+  })
+}
+
+export default defineConfig(({ mode }) => {
+  const root = process.env.OPENCORE_VIEW_ROOT || process.cwd()
+  const outDir = process.env.OPENCORE_VIEW_OUTDIR
+
+  return createOpenCoreViteConfig({
+    root,
+    outDir,
+  })
+})

--- a/internal/templates/starter-project/vite.config.ts
+++ b/internal/templates/starter-project/vite.config.ts
@@ -11,6 +11,7 @@ export function createOpenCoreViteConfig(options: OpenCoreViteConfigOptions): Us
 
   return defineConfig({
     root,
+    base: './',
     resolve: {
       alias: {
         '@': path.join(root, 'src'),


### PR DESCRIPTION
### Motivation
- Consolidate frontend build behavior around Vite so projects use a single, predictable Vite configuration by default.
- Centralize CSS/PostCSS handling to avoid duplicated per-view setups and make monorepo workflows simpler.
- Let the CLI orchestrate builds (targeting views/resources) while letting Vite remain the canonical frontend tool.

### Description
- Add a shared root Vite helper and default config: `internal/templates/starter-project/vite.config.ts` exposes `createOpenCoreViteConfig` and a default export. 
- Add a shared PostCSS template: `internal/templates/starter-project/postcss.config.mjs` and include PostCSS/Tailwind-friendly tooling in the generated project `package.json` devDependencies (`vite`, `postcss`, `autoprefixer`).
- Update starter generation to emit root `vite.config.ts` and `postcss.config.mjs` by default via the template writer (`internal/templates/embed.go`).
- Improve Vite detection and build orchestration so a view is Vite-backed when either a local `vite.config.*` exists or a project-root `vite.config.*` (next to `opencore.config.ts`) exists, implemented in `internal/builder/builder.go` (`findViteConfigPath`, `findProjectRootFromPath`, `hasViteConfig`) and the embedded runner `internal/builder/embedded/views.js` (prefer local config; otherwise run Vite from project root using `--config` and `--root` targeted at the view).
- Document the convention and fallback behavior in `docs/configuration.md` under a new "Views Vite Configuration" section.
- Add tests and assertions to ensure starter templates include the new files/deps and that root-level Vite configs are detected (`internal/templates/embed_test.go`, `internal/builder/builder_test.go`).

### Testing
- Ran `go test ./internal/templates ./internal/builder/embedded` and the tests passed (`ok`).
- Attempted `go test ./internal/builder` but the run was blocked by the environment (Go module downloads from `proxy.golang.org` returned HTTP 403), so those tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cba2ff3fb08331929c847c3c7980c4)