### PR TITLE
Bug/#16 prevent cleanup of server.js/client.js during views-only dev rebuilds

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,6 +48,10 @@ The resolver detects known native packages and native package indicators such as
 
 Native packages are rejected in `bundle` mode and reported clearly for dependency-resolution flows.
 
+### Bug Fixes
+
+**Dev Mode UI Hot-Reload ([#16](https://github.com/newcore-network/opencore-cli/issues/16)):** Fixed an issue where `server.js` and `client.js` would disappear from the resource output directory when editing UI files (`.tsx`, `.jsx`) in dev mode. The incremental build now preserves sibling artifacts when rebuilding only views, instead of wiping the entire resource directory before the partial rebuild.
+
 ### Docs
 
 Added dependency resolver documentation and FiveM sandbox guidance:
@@ -57,6 +61,3 @@ Added dependency resolver documentation and FiveM sandbox guidance:
 
 Use `isolated` for production FiveM/RedM server resources that require runtime npm dependencies.
 
-### Bug Fixes
-
-**Dev Mode UI Hot-Reload (#16):** Fixed an issue where `server.js` and `client.js` would disappear from the resource output directory when editing UI files (`.tsx`, `.jsx`) in dev mode. The incremental build now preserves sibling artifacts when rebuilding only views, instead of wiping the entire resource directory before the partial rebuild.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,3 +56,7 @@ Added dependency resolver documentation and FiveM sandbox guidance:
 - `docs/adapters/fivem.md`
 
 Use `isolated` for production FiveM/RedM server resources that require runtime npm dependencies.
+
+### Bug Fixes
+
+**Dev Mode UI Hot-Reload (#16):** Fixed an issue where `server.js` and `client.js` would disappear from the resource output directory when editing UI files (`.tsx`, `.jsx`) in dev mode. The incremental build now preserves sibling artifacts when rebuilding only views, instead of wiping the entire resource directory before the partial rebuild.

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -315,16 +315,18 @@ func (b *Builder) BuildTasksContext(ctx context.Context, tasks []BuildTask) ([]B
 	}
 
 	uniqueResources := make(map[string]struct{})
+	resourceTasks := make(map[string][]BuildTask)
 	for _, task := range tasks {
 		baseResource := strings.Split(task.ResourceName, "/")[0]
 		uniqueResources[baseResource] = struct{}{}
+		resourceTasks[baseResource] = append(resourceTasks[baseResource], task)
 	}
 	if sharedName != "" {
 		uniqueResources[sharedName] = struct{}{}
 	}
 
 	for baseResource := range uniqueResources {
-		if err := b.cleanResourceOutputDir(baseResource); err != nil {
+		if err := b.cleanResourceOutputForTasks(baseResource, resourceTasks[baseResource]); err != nil {
 			return nil, fmt.Errorf("failed to clean resource output directory: %w", err)
 		}
 	}
@@ -1583,6 +1585,34 @@ func (b *Builder) hasClientCode(resourcePath string) bool {
 	}
 
 	return false
+}
+
+// cleanResourceOutputForTasks cleans a resource's output before a rebuild,
+// scoped to the tasks being built. A views-only rebuild (e.g. editing a .tsx UI
+// file in dev mode) cleans only the views subdirectory; wiping the whole
+// resource dir would delete the sibling server.js/client.js that aren't being
+// regenerated.
+func (b *Builder) cleanResourceOutputForTasks(resourceName string, tasks []BuildTask) error {
+	// No tasks (shared-dependency resource) or any non-views task means the
+	// whole resource output is regenerated, so a full clean is safe.
+	if len(tasks) == 0 {
+		return b.cleanResourceOutputDir(resourceName)
+	}
+	for _, task := range tasks {
+		if task.Type != TypeViews {
+			return b.cleanResourceOutputDir(resourceName)
+		}
+	}
+
+	for _, task := range tasks {
+		if viewsDir := strings.TrimSpace(task.OutDir); viewsDir != "" {
+			if err := os.RemoveAll(viewsDir); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (b *Builder) cleanResourceOutputDir(resourceName string) error {

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -685,6 +685,83 @@ func TestCollectAllTasks_ExplicitResourceViewsInheritResourceDefaults(t *testing
 	t.Fatal("Expected xchat/ui views task")
 }
 
+func TestCleanResourceOutputForTasks_ViewsOnlyKeepsSiblings(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Name:   "test-project",
+		OutDir: tmp,
+		Core:   config.CoreConfig{Path: "./core", ResourceName: "core"},
+		Build:  config.BuildConfig{},
+	}
+	builder := New(cfg)
+
+	layout := builder.resourceLayout("team")
+
+	// Seed a fully-built resource: server.js, client.js, fxmanifest.lua and ui/.
+	if err := os.MkdirAll(layout.ViewsOutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	serverJS := filepath.Join(layout.ServerOutDir, "server.js")
+	clientJS := filepath.Join(layout.ClientOutDir, "client.js")
+	manifest := filepath.Join(layout.ServerOutDir, "fxmanifest.lua")
+	staleView := filepath.Join(layout.ViewsOutDir, "old.js")
+	for _, f := range []string{serverJS, clientJS, manifest, staleView} {
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	viewsTask := BuildTask{
+		ResourceName: "team/ui",
+		Type:         TypeViews,
+		OutDir:       layout.ViewsOutDir,
+	}
+	if err := builder.cleanResourceOutputForTasks("team", []BuildTask{viewsTask}); err != nil {
+		t.Fatalf("cleanResourceOutputForTasks returned error: %v", err)
+	}
+
+	// Sibling artifacts must survive a views-only clean.
+	for _, f := range []string{serverJS, clientJS, manifest} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected %s to survive views-only clean, but it was removed", filepath.Base(f))
+		}
+	}
+	// The views output dir itself must be cleaned (stale assets removed).
+	if _, err := os.Stat(staleView); !os.IsNotExist(err) {
+		t.Errorf("expected stale view artifact to be removed from views output dir")
+	}
+}
+
+func TestCleanResourceOutputForTasks_FullRebuildCleansAll(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Name:   "test-project",
+		OutDir: tmp,
+		Core:   config.CoreConfig{Path: "./core", ResourceName: "core"},
+		Build:  config.BuildConfig{},
+	}
+	builder := New(cfg)
+	layout := builder.resourceLayout("team")
+
+	if err := os.MkdirAll(layout.ServerOutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(layout.ServerOutDir, "server.js")
+	if err := os.WriteFile(stale, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resourceTask := BuildTask{ResourceName: "team", Type: TypeResource, OutDir: layout.ServerOutDir}
+	viewsTask := BuildTask{ResourceName: "team/ui", Type: TypeViews, OutDir: layout.ViewsOutDir}
+	if err := builder.cleanResourceOutputForTasks("team", []BuildTask{resourceTask, viewsTask}); err != nil {
+		t.Fatalf("cleanResourceOutputForTasks returned error: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("expected full rebuild to clean stale server.js")
+	}
+}
+
 func TestCollectAllTasks_BuildOptions(t *testing.T) {
 	serverFalse := &config.ResourceBuildSideConfig{Enabled: false}
 


### PR DESCRIPTION
When editing UI files in dev mode, the watcher now cleans only the views output directory instead of the entire resource directory. This preserves sibling artifacts (server.js, client.js, fxmanifest.lua) that aren't being regenerated.

Closes: #16 